### PR TITLE
Fix for Assets returning empty fields dict

### DIFF
--- a/contentful/cda/serialization.py
+++ b/contentful/cda/serialization.py
@@ -109,6 +109,7 @@ class ResourceFactory(object):
         """
         result = Asset(json['sys'])
         file_dict = json['fields']['file']
+        result.fields = json['fields']
         result.url = file_dict['url']
         result.mimeType = file_dict['contentType']
         return result


### PR DESCRIPTION
Not getting the 'fields' attributes, such as title or the image properties, when I fetch Assets, just an empty dict. Looks like maybe it's being dropped here?
