### PR TITLE
Use version 1.1.1 of enum34 (compatible with Python 3.5)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 deps = [
-    'enum34==1.0.4',
+    'enum34==1.1.1',
     'requests==2.4.3',
     'six==1.8.0',
     'python-dateutil==2.3'


### PR DESCRIPTION
See https://bitbucket.org/stoneleaf/enum34/issues/5/enum34-incompatible-with-python-35
