### PR TITLE
Support Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
 branches:
   except:
     - gh-pages
+matrix:
+  fast_finish: true
 sudo: false
 install:
   - python setup.py install

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Release History
 0.9.3 (in-development)
 ++++++++++++++++++++++
 
-- TBD.
+- Compatability with Python 3.5.
 
 0.9.2 (2015-07-08)
 ++++++++++++++++++

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ deps = [
 ]
 
 test_deps = [
-    'mock==1.0.1',
-    'vcrpy==1.1.3',
+    'mock',
+    'vcrpy==1.7.4',
     'pytest==2.6.4'
 ]
 
@@ -66,6 +66,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4'
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5'
     ]
 )


### PR DESCRIPTION
- Upgraded vcrpy to version 1.7.4
- Removed the version restriction for mock
- Added Python 3.5 to the TravisCI test matrix
