### PR TITLE
docs: Add imports to code examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,8 @@ The ``Client`` class manages all your interaction with the Contentful Delivery A
 
 .. code-block:: python
 
+    from contentful import Client
+
     client = Client('space-id', 'access-token')
 
 ------------------
@@ -34,6 +36,8 @@ Fetching Resources
 The simplest form of fetching resources follows:
 
 .. code-block:: python
+
+    from contentful.cda.resources import Asset, ContentType, Entry
 
     client.fetch(Asset).all()         # Returns an array of Assets
     client.fetch(Asset).first()       # Returns the first Asset available
@@ -94,6 +98,9 @@ Custom Entry classes can be declared by providing a Content Type ID value and by
 A custom Entry class for this Content Type can be defined as follows:
 
 .. code-block:: python
+
+    from contentful.cda.fields import Date, Field, Link, List, Number, Text
+    from contentful.cda.resources import Asset, ContentType, Entry
 
     class Cat(Entry):
         __content_type__ = 'cat'


### PR DESCRIPTION
Overview
--------

It was unclear from where certain classes in the code examples came.


Changes
-------

- Add import statements to code that uses library Classes