### PR TITLE
docs: Enumerate `Client` constructor args

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,13 @@ The ``Client`` class manages all your interaction with the Contentful Delivery A
 
     client = Client('space-id', 'access-token')
 
+The constructor also takes the following keyword arguments:
+
+- ``custom_entries`` (list) Optional list of `Entry` subclasses (see below)
+- ``secure`` (bool) Indicates whether the connection should be encrypted or not, default: ``True``
+- ``endpoint`` (str) Custom remote API endpoint, default: ``cdn.contentful.com``
+- ``resolve_links`` (bool) Indicates whether or not to resolve links automatically, default: ``True``
+
 ------------------
 Fetching Resources
 ------------------


### PR DESCRIPTION
- Document the kwargs that the `Client` class constructor accepts